### PR TITLE
Added missing request_id to VKWebAppCallAPIMethod parameters definition

### DIFF
--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -660,7 +660,7 @@ export type RequestPropsMap = {
   VKWebAppAddToCommunity: {};
   VKWebAppAllowMessagesFromGroup: { group_id: number; key?: string };
   VKWebAppAllowNotifications: {};
-  VKWebAppCallAPIMethod: { method: string; params: Record<string, string | number> };
+  VKWebAppCallAPIMethod: { method: string; params: Record<string, string | number>; request_id?: string };
   VKWebAppGetAuthToken: { app_id: number; scope: string };
   VKWebAppClose: { status: AppCloseStatus; payload?: any };
   VKWebAppOpenApp: { app_id: number; location?: string };


### PR DESCRIPTION
После рефакторинга пропал request_id в параметрах к VKWebAppCallAPIMethod, хотя он остался в официальной документации: https://vk.com/dev/vk_connect_events_7?f=%D0%92%D1%8B%D0%B7%D0%BE%D0%B2%20%D0%BC%D0%B5%D1%82%D0%BE%D0%B4%D0%BE%D0%B2%20API